### PR TITLE
fix: add missing finalize() in DuplexView offline_inference to fix state machine error

### DIFF
--- a/core/processors/unified.py
+++ b/core/processors/unified.py
@@ -1117,7 +1117,9 @@ class DuplexView:
                     
                     # 生成
                     result = self.generate()
-                    
+
+                    self.finalize()
+
                     chunk_elapsed = (time.time() - chunk_start) * 1000
                     
                     # 记录结果


### PR DESCRIPTION
### Describe the bug
In `core/processors/unified.py`, the `offline_inference` method of `DuplexView` processes audio chunks in a loop. However, it fails to call `self.finalize()` at the end of each chunk iteration. 

When processing an audio file that is longer than a single chunk, this omission causes a state machine error during the second chunk's prefill:
`ERROR: 离线推理失败: streaming_prefill called before finalize_unit()! 必须在 streaming_generate 之后调用 finalize_unit() 再进入下一轮 prefill。`

As a result, several duplex tests in `tests/test_duplex.py` fail by default.

### Solution
Added the missing `self.finalize()` call after `self.generate()` within the `offline_inference` loop. This correctly maintains the duplex state window and lifecycle.

### Testing
Ran the official tests suite. The failing GPU tests in `tests/test_duplex.py` now pass successfully.