### PR TITLE
content

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ instead of the PyTorch backend.
 
 Use the C++ backend when you need:
 
-- Lower VRAM (Q4_K_M needs roughly 9 GB instead of ~22 GB)
+- Lower VRAM
 - Lower TTFT and faster decode on the same hardware
 - A self-contained `llama-server` process that you can also call directly via HTTP
 
@@ -28,6 +28,11 @@ frontend) stays the same — only the inference backend swaps out.
 ---
 
 ## 2. Build `llama-server`
+
+> Prefer not to compile? `tc-mb/llama.cpp-omni` ships pre-built
+> one-click installers (Comni for Windows / macOS) on its
+> [Releases page](https://github.com/tc-mb/llama.cpp-omni/releases/latest).
+> The instructions below are for the from-source path used by this repo.
 
 ```bash
 git clone https://github.com/tc-mb/llama.cpp-omni.git

--- a/README_zh.md
+++ b/README_zh.md
@@ -8,7 +8,7 @@
 
 什么时候用 C++ 后端：
 
-- 显存吃紧（Q4_K_M 大约 9 GB，PyTorch 路径约 22 GB）
+- 显存吃紧
 - 想要更低的 TTFT 与更快的解码
 - 需要一个独立的 `llama-server` 进程，可单独通过 HTTP 调用
 
@@ -28,6 +28,10 @@
 ---
 
 ## 2. 编译 `llama-server`
+
+> 不想自己编译？`tc-mb/llama.cpp-omni` 在 [Releases 页面](https://github.com/tc-mb/llama.cpp-omni/releases/latest)
+> 提供了一键安装包（Comni for Windows / macOS），下载即用。
+> 下面这一节是给走源码路径（也就是本仓库这套部署方式）的人看的。
 
 ```bash
 git clone https://github.com/tc-mb/llama.cpp-omni.git

--- a/docs/en/cpp-backend.md
+++ b/docs/en/cpp-backend.md
@@ -6,7 +6,7 @@ instead of the PyTorch backend.
 
 Use the C++ backend when you need:
 
-- Lower VRAM (Q4_K_M needs roughly 9 GB instead of ~22 GB)
+- Lower VRAM
 - Lower TTFT and faster decode on the same hardware
 - A self-contained `llama-server` process that you can also call directly via HTTP
 
@@ -26,6 +26,11 @@ frontend) stays the same — only the inference backend swaps out.
 ---
 
 ## 2. Build `llama-server`
+
+> Prefer not to compile? `tc-mb/llama.cpp-omni` ships pre-built
+> one-click installers (Comni for Windows / macOS) on its
+> [Releases page](https://github.com/tc-mb/llama.cpp-omni/releases/latest).
+> The instructions below are for the from-source path used by this repo.
 
 ```bash
 git clone https://github.com/tc-mb/llama.cpp-omni.git

--- a/docs/zh/cpp-backend.md
+++ b/docs/zh/cpp-backend.md
@@ -6,7 +6,7 @@
 
 什么时候用 C++ 后端：
 
-- 显存吃紧（Q4_K_M 大约 9 GB，PyTorch 路径约 22 GB）
+- 显存吃紧
 - 想要更低的 TTFT 与更快的解码
 - 需要一个独立的 `llama-server` 进程，可单独通过 HTTP 调用
 
@@ -26,6 +26,10 @@
 ---
 
 ## 2. 编译 `llama-server`
+
+> 不想自己编译？`tc-mb/llama.cpp-omni` 在 [Releases 页面](https://github.com/tc-mb/llama.cpp-omni/releases/latest)
+> 提供了一键安装包（Comni for Windows / macOS），下载即用。
+> 下面这一节是给走源码路径（也就是本仓库这套部署方式）的人看的。
 
 ```bash
 git clone https://github.com/tc-mb/llama.cpp-omni.git


### PR DESCRIPTION
- Remove the "(Q4_K_M ≈ 9 GB vs ~22 GB)" parenthetical from the intro bullet; just say "Lower VRAM". The exact number depends on ctx-size / KV / encoders and the bare 9 GB figure was misleading.
- Add a callout under "Build llama-server" telling readers they can also grab the pre-built one-click Comni installer (Win / macOS) from tc-mb/llama.cpp-omni Releases instead of building from source.

Same edits applied to README and docs/{en,zh}/cpp-backend.md.

Made-with: Cursor