### PR TITLE
feat: add TTS toggle checkbox to omni and audio-duplex frontend

### DIFF
--- a/static/audio-duplex/audio-duplex-app.js
+++ b/static/audio-duplex/audio-duplex-app.js
@@ -967,6 +967,7 @@ async function startSession() {
     // Build prepare payload
     const preparePayload = {
         config: { length_penalty: parseFloat(document.getElementById('duplexLengthPenalty').value) || 1.05 },
+        use_tts: document.getElementById('ttsEnabled').checked,
     };
     const refBase64 = refAudio.getBase64();
     if (refBase64) preparePayload.ref_audio_base64 = refBase64;

--- a/static/audio-duplex/audio_duplex.html
+++ b/static/audio-duplex/audio_duplex.html
@@ -124,6 +124,10 @@
                     <input type="number" class="cg-input-sm" id="duplexLengthPenalty" value="1.05" min="0.1" max="5.0" step="0.05">
                     <span style="font-size:10px;color:#888;">&gt;1 = longer</span>
                 </div>
+                <div class="cg-row inline" data-tip="Enable text-to-speech audio response for the session">
+                    <span class="cg-label" style="flex:none;">TTS Response</span>
+                    <input type="checkbox" id="ttsEnabled" checked>
+                </div>
             </div>
         </details>
         <details class="config-group">

--- a/static/omni/omni-app.js
+++ b/static/omni/omni-app.js
@@ -1597,6 +1597,7 @@ async function startSession() {
     const preparePayload = {
         config: { length_penalty: parseFloat(document.getElementById('omniLengthPenalty').value) || 1.0 },
         max_slice_nums: getEffectiveMaxSliceNums(),
+        use_tts: document.getElementById('ttsEnabled').checked,
     };
     const refBase64 = refAudio.getBase64();
     if (refBase64) preparePayload.ref_audio_base64 = refBase64;

--- a/static/omni/omni.html
+++ b/static/omni/omni.html
@@ -198,6 +198,10 @@
                     <input type="checkbox" id="visionHD">
                     <span style="font-size:10px;color:#888;" id="visionHint">64 tok</span>
                 </div>
+                <div class="cg-row inline" data-tip="Enable text-to-speech audio response for the session">
+                    <span class="cg-label" style="flex:none;">TTS Response</span>
+                    <input type="checkbox" id="ttsEnabled" checked>
+                </div>
             </div>
         </details>
         <details class="config-group">


### PR DESCRIPTION
## Summary
- Add "TTS Response" checkbox to omni.html Vision Settings and audio_duplex.html Session panel (default checked for backward compatibility)
- Pass `use_tts` in `session.init` preparePayload from omni-app.js and audio-duplex-app.js

## Usage
Users can toggle TTS before starting a duplex session. The `use_tts` flag is sent in `session.init` and consumed by the C++ backend.