### PR TITLE
Add realtime multimodal token usage

### DIFF
--- a/MiniCPMO45/configuration_minicpmo.py
+++ b/MiniCPMO45/configuration_minicpmo.py
@@ -101,9 +101,6 @@ class MiniCPMTTSConfig(PretrainedConfig):
         backbone_model: str = "llama",
         audio_tokenizer_type: str = "wavtokenizer",
         audio_tokenizer_sample_rate: int = 24000,
-        top_p: float = 0.85,
-        top_k: int = 25,
-        repetition_penalty: float = 1.05,
         streaming_sliding_window: bool = False,
         streaming_sliding_window_max_text_len: int = 500,
         streaming_sliding_window_average_speed: int = 5,
@@ -159,9 +156,6 @@ class MiniCPMTTSConfig(PretrainedConfig):
         self.backbone_model = backbone_model
         self.audio_tokenizer_type = audio_tokenizer_type
         self.audio_tokenizer_sample_rate = audio_tokenizer_sample_rate
-        self.top_p = top_p
-        self.top_k = top_k
-        self.repetition_penalty = repetition_penalty
 
         self.streaming_sliding_window = streaming_sliding_window
         self.streaming_sliding_window_max_text_len = streaming_sliding_window_max_text_len

--- a/MiniCPMO45/configuration_minicpmo.py
+++ b/MiniCPMO45/configuration_minicpmo.py
@@ -101,6 +101,9 @@ class MiniCPMTTSConfig(PretrainedConfig):
         backbone_model: str = "llama",
         audio_tokenizer_type: str = "wavtokenizer",
         audio_tokenizer_sample_rate: int = 24000,
+        top_p: float = 0.85,
+        top_k: int = 25,
+        repetition_penalty: float = 1.05,
         streaming_sliding_window: bool = False,
         streaming_sliding_window_max_text_len: int = 500,
         streaming_sliding_window_average_speed: int = 5,
@@ -156,6 +159,9 @@ class MiniCPMTTSConfig(PretrainedConfig):
         self.backbone_model = backbone_model
         self.audio_tokenizer_type = audio_tokenizer_type
         self.audio_tokenizer_sample_rate = audio_tokenizer_sample_rate
+        self.top_p = top_p
+        self.top_k = top_k
+        self.repetition_penalty = repetition_penalty
 
         self.streaming_sliding_window = streaming_sliding_window
         self.streaming_sliding_window_max_text_len = streaming_sliding_window_max_text_len

--- a/MiniCPMO45/modeling_minicpmo_unified.py
+++ b/MiniCPMO45/modeling_minicpmo_unified.py
@@ -4589,6 +4589,10 @@ class DuplexCapability:
         cost_audio_process = 0.0
         cost_audio_embed = 0.0
         cost_audio_feed = 0.0
+        input_text_tokens = 0
+        input_audio_tokens = 0
+        input_vision_tokens = 0
+        n_vision_slices = 0
 
         def _make_result(success, reasons=""):
             reason = reasons
@@ -4605,6 +4609,10 @@ class DuplexCapability:
                 "cost_audio_embed": cost_audio_embed,
                 "cost_audio_feed": cost_audio_feed,
                 "cost_all": time.time() - start_time,
+                "input_text_tokens": input_text_tokens,
+                "input_audio_tokens": input_audio_tokens,
+                "input_vision_tokens": input_vision_tokens,
+                "n_vision_slices": n_vision_slices,
             }
 
         if self.is_session_stop_set():
@@ -4641,6 +4649,7 @@ class DuplexCapability:
         # Step 1: Feed <unit> token
         self.decoder.feed(self.decoder.embed_token(self.unit_token_id))
         self._current_unit_prefill_tokens.append(self.unit_token_id)
+        input_text_tokens += 1
 
         # Step 2: process image
         if has_frames:
@@ -4761,6 +4770,13 @@ class DuplexCapability:
                                 (self.decoder.embed_token(self.slice_end_token_id), False, self.slice_end_token_id)
                             )
                             embed_idx += 1
+
+                n_vision_slices = sum(slice_counts)
+                for embed, _, token_id in feed_operations:
+                    if token_id is not None:
+                        input_text_tokens += 1
+                    else:
+                        input_vision_tokens += embed.shape[0] if embed.dim() > 1 else 1
 
                 # Mark the last operation for VISION mode logits
                 if feed_operations:
@@ -4897,6 +4913,7 @@ class DuplexCapability:
             # Schema tracking: 用元组标记 audio embedding: ("audio", dim)
             embed_dim = audio_embeds.shape[0] if len(audio_embeds.shape) > 1 else 1
             self._current_unit_prefill_tokens.append(("audio", embed_dim))
+            input_audio_tokens += embed_dim
 
             if self.audio_chunk_idx == 0:
                 cfg = self.processor._streaming_mel_processor.get_config()

--- a/core/processors/pytorch_backend.py
+++ b/core/processors/pytorch_backend.py
@@ -47,6 +47,7 @@ class PyTorchBackend:
 
         self.status = "loading"
         self.processor = None
+        self._last_duplex_prepare_usage: Dict[str, int] = {}
 
         # Duplex 暂停超时监控 task
         self._duplex_timeout_task: Optional[asyncio.Task] = None
@@ -253,11 +254,29 @@ class PyTorchBackend:
         if sampling:
             self.set_duplex_config(sampling)
         duplex_view = self.processor.set_duplex_mode()
-        return duplex_view.prepare(
+        self._last_duplex_prepare_usage = {}
+        prompt = duplex_view.prepare(
             system_prompt_text=system_prompt_text,
             ref_audio_path=ref_audio_path or self.ref_audio_path,
             prompt_wav_path=prompt_wav_path,
         )
+        actual_system_prompt = system_prompt_text or "Streaming Omni Conversation."
+        prefix = f"<|im_start|>system\n{actual_system_prompt}\n<|audio_start|>"
+        suffix = "<|audio_end|><|im_end|>"
+        tokenizer = duplex_view._model.duplex.tokenizer
+        text_tokens = len(tokenizer.encode(prefix, add_special_tokens=False))
+        text_tokens += len(tokenizer.encode(suffix, add_special_tokens=False))
+        cache_tokens = int(duplex_view._model.duplex.decoder.get_cache_length())
+        self._last_duplex_prepare_usage = {
+            "input_text_tokens": text_tokens,
+            "input_audio_tokens": max(cache_tokens - text_tokens, 0),
+        }
+        return prompt
+
+    def duplex_prepare_usage(self) -> Dict[str, int]:
+        """Return token counts added while initializing the duplex session."""
+
+        return dict(self._last_duplex_prepare_usage)
 
     def duplex_prefill(
         self,

--- a/examples/realtime/audio_probe.py
+++ b/examples/realtime/audio_probe.py
@@ -177,11 +177,22 @@ class ProbeState:
     output_chunk_eot: list[bool] = field(default_factory=list)
     ping_rtts_ms: list[float] = field(default_factory=list)
     events: list[dict[str, Any]] = field(default_factory=list)
+    latest_usage: dict[str, Any] | None = None
+    chunk_usage_by_index: dict[int, dict[str, Any]] = field(default_factory=dict)
 
     def event(self, typ: str, **kwargs: Any) -> None:
         item = {"t_ms": ms(now() - self.started_s), "type": typ}
         item.update(kwargs)
         self.events.append(item)
+
+    def capture_usage(self, message: dict[str, Any]) -> None:
+        usage = message.get("usage")
+        if isinstance(usage, dict):
+            self.latest_usage = usage
+        chunk_usage = message.get("chunk_usage")
+        chunk_index = message.get("chunk_index")
+        if isinstance(chunk_usage, dict) and isinstance(chunk_index, int):
+            self.chunk_usage_by_index[chunk_index] = chunk_usage
 
 
 async def measure_ping(ws: websockets.ClientConnection, count: int, interval_s: float) -> list[float]:
@@ -285,6 +296,7 @@ async def run_probe(args: argparse.Namespace) -> dict[str, Any]:
                 break
             msg = json.loads(raw)
             msg_type = msg.get("type", "")
+            state.capture_usage(msg)
             state.event(f"server.{msg_type}")
 
             if msg_type in ("session.queue_done", "queue_done") and not session_created:
@@ -401,6 +413,13 @@ def build_result(args: argparse.Namespace, state: ProbeState, playback: Playback
         **summarize(jitter_samples, "chunk_jitter"),
         **summarize(late_jitter_samples, "chunk_late_jitter"),
         **summarize(early_jitter_samples, "chunk_early_jitter"),
+        "usage": state.latest_usage,
+        "chunk_usage_count": len(state.chunk_usage_by_index),
+        "last_chunk_usage": (
+            state.chunk_usage_by_index[max(state.chunk_usage_by_index)]
+            if state.chunk_usage_by_index
+            else None
+        ),
     }
 
     if state.ping_rtts_ms:
@@ -438,6 +457,12 @@ def print_human(result: dict[str, Any]) -> None:
     print(f"audio_ahead_min/p50/p90_ms: {fmt(result.get('audio_ahead_min_ms'))} / {fmt(result.get('audio_ahead_p50_ms'))} / {fmt(result.get('audio_ahead_p90_ms'))}")
     print(f"underrun_count: {fmt(result.get('underrun_count'))}")
     print(f"underrun_total_ms: {fmt(result.get('underrun_total_ms'))}")
+    if result.get("usage"):
+        print("usage:")
+        print(json.dumps(result["usage"], ensure_ascii=False, indent=2))
+        print(f"chunk_usage_count: {result.get('chunk_usage_count')}")
+        print("last_chunk_usage:")
+        print(json.dumps(result.get("last_chunk_usage"), ensure_ascii=False, indent=2))
 
 
 def fmt(value: Any) -> str:

--- a/examples/realtime/video_probe.py
+++ b/examples/realtime/video_probe.py
@@ -177,11 +177,22 @@ class ProbeState:
     input_frames_sent: int = 0
     listen_events: int = 0
     events: list[dict[str, Any]] = field(default_factory=list)
+    latest_usage: dict[str, Any] | None = None
+    chunk_usage_by_index: dict[int, dict[str, Any]] = field(default_factory=dict)
 
     def event(self, typ: str, **kwargs: Any) -> None:
         item = {"t_ms": ms(now() - self.started_s), "type": typ}
         item.update(kwargs)
         self.events.append(item)
+
+    def capture_usage(self, message: dict[str, Any]) -> None:
+        usage = message.get("usage")
+        if isinstance(usage, dict):
+            self.latest_usage = usage
+        chunk_usage = message.get("chunk_usage")
+        chunk_index = message.get("chunk_index")
+        if isinstance(chunk_usage, dict) and isinstance(chunk_index, int):
+            self.chunk_usage_by_index[chunk_index] = chunk_usage
 
 
 async def sender(
@@ -263,6 +274,7 @@ async def run_probe(args: argparse.Namespace) -> dict[str, Any]:
                     raw = await (ws.recv() if timeout is None else asyncio.wait_for(ws.recv(), timeout))
                     msg = json.loads(raw)
                     msg_type = msg.get("type", "")
+                    state.capture_usage(msg)
                     state.event(f"server.{msg_type}")
 
                     if msg_type in ("session.queue_done", "queue_done") and sender_task is None:
@@ -353,6 +365,13 @@ def build_result(args: argparse.Namespace, state: ProbeState, source_audio_chunk
         "text": "".join(state.text_chunks),
         "output_audio_chunks": len(state.output_chunk_times_s),
         **summarize(chunk_intervals_ms, "chunk_interarrival"),
+        "usage": state.latest_usage,
+        "chunk_usage_count": len(state.chunk_usage_by_index),
+        "last_chunk_usage": (
+            state.chunk_usage_by_index[max(state.chunk_usage_by_index)]
+            if state.chunk_usage_by_index
+            else None
+        ),
         "events": state.events if args.include_events else None,
     }
 
@@ -368,6 +387,12 @@ def print_human(result: dict[str, Any]) -> None:
     if result.get("text"):
         print("text:")
         print(result["text"])
+    if result.get("usage"):
+        print("usage:")
+        print(json.dumps(result["usage"], ensure_ascii=False, indent=2))
+        print(f"chunk_usage_count: {result.get('chunk_usage_count')}")
+        print("last_chunk_usage:")
+        print(json.dumps(result.get("last_chunk_usage"), ensure_ascii=False, indent=2))
 
 
 def parse_args() -> argparse.Namespace:

--- a/py_backend/server.py
+++ b/py_backend/server.py
@@ -24,6 +24,7 @@ from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconn
 
 from core.processors.backend_factory import create_backend
 from py_backend.media import decode_audio_base64, decode_frame_base64_list
+from py_backend.usage import SessionUsage, TokenUsage
 from py_backend.voice import resolve_duplex_voice_refs
 from py_backend.chat_util import (
     convert_to_model_msgs,
@@ -166,6 +167,8 @@ class BackendProtocolSession:
         self._finalize_task: Optional[asyncio.Task[None]] = None
         self._op_lock = asyncio.Lock()
         self._active_response_id: Optional[str] = None
+        self._usage = SessionUsage()
+        self._usage_chunk_index = 0
 
     async def send(self, event_type: str, **fields: Any) -> None:
         data = {"type": event_type, **{k: v for k, v in fields.items() if v is not None}}
@@ -186,6 +189,7 @@ class BackendProtocolSession:
             session_id=self.session_id,
             mode=self.mode,
             metrics=self._safe_metrics(),
+            usage=self._usage.snapshot(),
         )
 
     async def push(self, message: Dict[str, Any]) -> None:
@@ -216,7 +220,12 @@ class BackendProtocolSession:
 
         if emit_event:
             with suppress(Exception):
-                await self.send("session.closed", session_id=self.session_id, reason=reason)
+                await self.send(
+                    "session.closed",
+                    session_id=self.session_id,
+                    reason=reason,
+                    usage=self._usage.snapshot(),
+                )
         with suppress(Exception):
             await self.ws.close(code=1000, reason=reason)
         await self.state.forget(self.session_id)
@@ -230,6 +239,7 @@ class BackendProtocolSession:
                 session_id=self.session_id,
                 reason=reason,
                 diagnostic={"message": message} if message else None,
+                usage=self._usage.snapshot(),
             )
         with suppress(Exception):
             await self.ws.close(code=1011, reason=reason)
@@ -274,6 +284,13 @@ class BackendProtocolSession:
             )
         finally:
             refs.cleanup()
+
+        prepare_usage = getattr(self.backend, "duplex_prepare_usage", None)
+        if callable(prepare_usage):
+            try:
+                self._usage.add(TokenUsage.from_counts(prepare_usage()))
+            except Exception:
+                logger.exception("failed to collect duplex prepare usage")
 
     async def _push_turn_based(self, payload: Dict[str, Any]) -> None:
         async with self._op_lock:
@@ -426,10 +443,28 @@ class BackendProtocolSession:
             metrics["prefill_ms"] = round(prefill_ms, 1)
             metrics["wall_clock_ms"] = round(wall_clock_ms, 1)
             if isinstance(prefill_result, dict):
-                n_vision_images = prefill_result.get("n_vision_images")
-                if n_vision_images is not None:
-                    metrics["vision_slices"] = n_vision_images
-                    metrics["vision_tokens"] = int(n_vision_images) * 64
+                n_vision_slices = prefill_result.get(
+                    "n_vision_slices",
+                    prefill_result.get("n_vision_images"),
+                )
+                if n_vision_slices is not None:
+                    metrics["vision_slices"] = n_vision_slices
+                vision_tokens = prefill_result.get("input_vision_tokens")
+                if vision_tokens is not None:
+                    metrics["vision_tokens"] = vision_tokens
+
+            chunk_index = self._usage_chunk_index
+            chunk_usage = TokenUsage.from_duplex_chunk(
+                prefill_result,
+                result,
+                has_video=bool(decoded_frames.frame_list),
+            )
+            usage_fields = {
+                "chunk_index": chunk_index,
+                "usage": self._usage.add(chunk_usage),
+                "chunk_usage": chunk_usage.to_dict(),
+            }
+            self._usage_chunk_index += 1
 
             if result.is_listen:
                 await self.send_output_delta(
@@ -438,6 +473,7 @@ class BackendProtocolSession:
                     response_id=self._active_response_id,
                     input_id=input_id,
                     metrics=metrics,
+                    **usage_fields,
                 )
                 self._active_response_id = None
                 self._schedule_finalize()
@@ -454,6 +490,7 @@ class BackendProtocolSession:
                     input_id=input_id,
                     text=result.text,
                     metrics=metrics,
+                    **usage_fields,
                 )
             if result.audio_data:
                 await self.send_output_delta(
@@ -463,6 +500,7 @@ class BackendProtocolSession:
                     input_id=input_id,
                     audio=result.audio_data,
                     metrics=metrics,
+                    **usage_fields,
                 )
             if result.end_of_turn:
                 await self.send_output_delta(
@@ -471,6 +509,7 @@ class BackendProtocolSession:
                     response_id=self._active_response_id,
                     input_id=input_id,
                     metrics=metrics,
+                    **usage_fields,
                 )
                 self._active_response_id = None
 

--- a/py_backend/usage.py
+++ b/py_backend/usage.py
@@ -1,0 +1,109 @@
+"""Realtime token usage accounting.
+
+The public payload mirrors the familiar ``usage`` shape while keeping
+multimodal token details. ``SessionUsage`` owns the session-wide accumulator;
+callers keep the returned per-chunk value alongside the cumulative snapshot.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping
+
+
+def _token_count(value: Any) -> int:
+    """Convert backend counters to a non-negative integer."""
+
+    if value is None:
+        return 0
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+@dataclass
+class TokenUsage:
+    input_text_tokens: int = 0
+    input_audio_tokens: int = 0
+    input_image_tokens: int = 0
+    input_video_tokens: int = 0
+    output_text_tokens: int = 0
+    output_audio_tokens: int = 0
+
+    @classmethod
+    def from_counts(cls, counts: Mapping[str, Any]) -> "TokenUsage":
+        return cls(
+            input_text_tokens=_token_count(counts.get("input_text_tokens")),
+            input_audio_tokens=_token_count(counts.get("input_audio_tokens")),
+            input_image_tokens=_token_count(counts.get("input_image_tokens")),
+            input_video_tokens=_token_count(counts.get("input_video_tokens")),
+            output_text_tokens=_token_count(counts.get("output_text_tokens")),
+            output_audio_tokens=_token_count(counts.get("output_audio_tokens")),
+        )
+
+    @classmethod
+    def from_duplex_chunk(
+        cls,
+        prefill_result: Any,
+        generate_result: Any,
+        *,
+        has_video: bool,
+    ) -> "TokenUsage":
+        prefill = prefill_result if isinstance(prefill_result, Mapping) else {}
+        vision_tokens = _token_count(prefill.get("input_vision_tokens"))
+        return cls(
+            input_text_tokens=_token_count(prefill.get("input_text_tokens")),
+            input_audio_tokens=_token_count(prefill.get("input_audio_tokens")),
+            input_image_tokens=0 if has_video else vision_tokens,
+            input_video_tokens=vision_tokens if has_video else 0,
+            output_text_tokens=_token_count(getattr(generate_result, "n_tokens", None)),
+            output_audio_tokens=_token_count(getattr(generate_result, "n_tts_tokens", None)),
+        )
+
+    def add(self, other: "TokenUsage") -> None:
+        self.input_text_tokens += other.input_text_tokens
+        self.input_audio_tokens += other.input_audio_tokens
+        self.input_image_tokens += other.input_image_tokens
+        self.input_video_tokens += other.input_video_tokens
+        self.output_text_tokens += other.output_text_tokens
+        self.output_audio_tokens += other.output_audio_tokens
+
+    def to_dict(self) -> Dict[str, Any]:
+        input_tokens = (
+            self.input_text_tokens
+            + self.input_audio_tokens
+            + self.input_image_tokens
+            + self.input_video_tokens
+        )
+        output_tokens = self.output_text_tokens + self.output_audio_tokens
+        return {
+            "total_tokens": input_tokens + output_tokens,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "input_token_details": {
+                "text_tokens": self.input_text_tokens,
+                "audio_tokens": self.input_audio_tokens,
+                "image_tokens": self.input_image_tokens,
+                "video_tokens": self.input_video_tokens,
+                "cached_tokens": 0,
+            },
+            "output_token_details": {
+                "text_tokens": self.output_text_tokens,
+                "audio_tokens": self.output_audio_tokens,
+            },
+        }
+
+
+class SessionUsage:
+    """Accumulate token counts for one realtime session."""
+
+    def __init__(self) -> None:
+        self._total = TokenUsage()
+
+    def add(self, usage: TokenUsage) -> Dict[str, Any]:
+        self._total.add(usage)
+        return self.snapshot()
+
+    def snapshot(self) -> Dict[str, Any]:
+        return self._total.to_dict()

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,128 @@
+import base64
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from py_backend.server import BackendProtocolSession, BackendServerState
+from py_backend.usage import SessionUsage, TokenUsage
+
+
+def test_duplex_chunk_usage_keeps_modalities_separate():
+    usage = TokenUsage.from_duplex_chunk(
+        {
+            "input_text_tokens": 5,
+            "input_audio_tokens": 50,
+            "input_vision_tokens": 128,
+        },
+        SimpleNamespace(n_tokens=7, n_tts_tokens=25),
+        has_video=True,
+    ).to_dict()
+
+    assert usage == {
+        "total_tokens": 215,
+        "input_tokens": 183,
+        "output_tokens": 32,
+        "input_token_details": {
+            "text_tokens": 5,
+            "audio_tokens": 50,
+            "image_tokens": 0,
+            "video_tokens": 128,
+            "cached_tokens": 0,
+        },
+        "output_token_details": {
+            "text_tokens": 7,
+            "audio_tokens": 25,
+        },
+    }
+
+
+def test_session_usage_accumulates_from_session_start():
+    session = SessionUsage()
+    session.add(TokenUsage(input_text_tokens=10, input_audio_tokens=20))
+
+    current = TokenUsage(
+        input_text_tokens=1,
+        input_audio_tokens=50,
+        output_text_tokens=4,
+        output_audio_tokens=25,
+    )
+    cumulative = session.add(current)
+
+    assert current.to_dict()["total_tokens"] == 80
+    assert cumulative["total_tokens"] == 110
+    assert cumulative["input_token_details"]["text_tokens"] == 11
+    assert cumulative["input_token_details"]["audio_tokens"] == 70
+    assert cumulative["output_token_details"]["text_tokens"] == 4
+    assert cumulative["output_token_details"]["audio_tokens"] == 25
+    assert cumulative["input_token_details"]["cached_tokens"] == 0
+
+
+def test_invalid_backend_counts_fall_back_to_zero():
+    usage = TokenUsage.from_counts({
+        "input_text_tokens": None,
+        "input_audio_tokens": -3,
+        "output_text_tokens": "bad",
+    })
+
+    assert usage.to_dict()["total_tokens"] == 0
+
+
+@pytest.mark.asyncio
+async def test_duplex_output_events_include_chunk_and_cumulative_usage():
+    class FakeWebSocket:
+        def __init__(self):
+            self.events = []
+
+        async def send_json(self, event):
+            self.events.append(event)
+
+    class FakeBackend:
+        def duplex_prefill(self, **_kwargs):
+            return {
+                "input_text_tokens": 1,
+                "input_audio_tokens": 50,
+                "input_vision_tokens": 0,
+                "n_vision_slices": 0,
+            }
+
+        def duplex_generate(self, **_kwargs):
+            return SimpleNamespace(
+                is_listen=False,
+                text="你好",
+                audio_data="audio",
+                end_of_turn=False,
+                n_tokens=3,
+                n_tts_tokens=25,
+            )
+
+        def duplex_finalize(self):
+            return None
+
+        def metrics(self):
+            return {}
+
+    backend = FakeBackend()
+    websocket = FakeWebSocket()
+    session = BackendProtocolSession(
+        session_id="test",
+        mode="full_duplex",
+        backend=backend,
+        ws=websocket,
+        state=BackendServerState(backend),
+    )
+    session.initialized = True
+    audio = base64.b64encode(np.zeros(16000, dtype=np.float32).tobytes()).decode()
+
+    await session.push({"type": "input.append", "input": {"audio": audio}})
+    await session._drain_finalize()
+
+    assert len(websocket.events) == 2
+    text_event, audio_event = websocket.events
+    assert text_event["kind"] == "text"
+    assert audio_event["kind"] == "audio"
+    assert text_event["chunk_index"] == audio_event["chunk_index"] == 0
+    assert text_event["chunk_usage"] == audio_event["chunk_usage"]
+    assert text_event["usage"] == audio_event["usage"]
+    assert text_event["chunk_usage"]["total_tokens"] == 79
+    assert text_event["usage"]["total_tokens"] == 79


### PR DESCRIPTION
## Summary

- Add session-cumulative `usage` and per-chunk `chunk_usage` to realtime duplex events.
- Track text, audio, image, video, LLM output, and TTS output tokens.
- Add `chunk_index` to correlate text/audio events produced by the same model chunk.
- Keep `cached_tokens` at `0`.
- Include final cumulative usage in session lifecycle events.
- Add missing TTS sampling defaults required by the Python backend.

## Testing

- 58 related unit tests passed.
- Real audio realtime E2E passed (`USAGE_E2E_OK`).
- Real video realtime E2E passed (`VIDEO_USAGE_E2E_OK`).
- Verified cumulative usage equals session initialization usage plus chunk usage.